### PR TITLE
Driving copyright date from JS

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -64,7 +64,7 @@ module.exports={
           ]
         }
       ],
-      "copyright": "Copyright © 2023 Sykes Holiday Cottages",
+      "copyright": `Copyright © ${new Date().getFullYear()} Sykes Holiday Cottages`,
       "logo": {
         "src": "img/sykes-primary-logo-white-small.svg"
       }


### PR DESCRIPTION
Drive the copywrite notice via JS and set it to the current year.

Tested locally.